### PR TITLE
Add RequestId Plug

### DIFF
--- a/lib/request_id.ex
+++ b/lib/request_id.ex
@@ -1,0 +1,34 @@
+defmodule Plexy.RequestId do
+  alias Plug.Conn
+  @behaviour Plug
+
+  def init(opts) do
+    %{req_headers:
+        Keyword.get(opts, :req_headers, ["request-id", "x-request-id"]),
+      res_header:
+        Keyword.get(opts, :res_header, "request-id")}
+  end
+
+  def call(conn, config) do
+    conn
+    |> get_request_ids(Map.get(config, :req_headers))
+    |> set_request_ids(Map.get(config, :res_header))
+  end
+
+  defp get_request_ids(conn, req_headers) do
+    {conn, Enum.join(req_headers, &get_request_id(conn, &1), ",")}
+  end
+
+  defp get_request_id(conn, header) do
+    case Conn.get_req_header(conn, header) |> String.split(",") do
+      [h | t] -> [Ecto.UUID.generate() | [h | t]]
+      _       -> [Ecto.UUID.generate()]
+    end
+  end
+
+  defp set_request_ids({conn, request_ids}, header) do
+    conn = Conn.put_resp_header(conn, header, request_ids)
+    %{conn | request_id: Enum.first(request_ids),
+             request_ids: request_ids}
+  end
+end

--- a/lib/request_id.ex
+++ b/lib/request_id.ex
@@ -44,9 +44,7 @@ defmodule Plexy.RequestId do
 
   defp get_request_id(conn, header) do
     Conn.get_req_header(conn, header)
-    |> List.flatten()
-    |> Enum.map(&String.split(&1, ","))
-    |> List.flatten()
+    |> Enum.flat_map(&String.split(&1, ","))
   end
 
   defp set_request_ids({conn, request_ids}, header) do

--- a/lib/request_id.ex
+++ b/lib/request_id.ex
@@ -1,14 +1,15 @@
 defmodule Plexy.RequestId do
   @moduledoc """
-  Injects a request id into the specified header for each request. Leaves
-  existing request ids in tact.
+  A plug that reads from specified :req_headers for given request ids,
+  prepends a new generated one, and adds all as a comma seperated list to the
+  specified res_header.
   """
   alias Plug.Conn
   @behaviour Plug
 
   @doc """
-  Initializes the plug. Returns a map with req_headers and
-  res_headers for use by the other functions.
+  Initializes the plug. Returns a configuration map with specified
+  :req_headers and :res_headers for use by the other functions.
   """
   def init(opts) do
     req_headers = case Keyword.get(opts, :req_headers, ["request-id", "x-request-id"]) do
@@ -21,9 +22,8 @@ defmodule Plexy.RequestId do
   end
 
   @doc """
-  Takes the req_headers from the config and adds a UUID for our
-  request header and then shoves that all into the response header
-  also sets an assigns
+  Reads :res_headers, injects a new uuid, than adds them all to the specified
+  :res_headers and the conn's :assigns
   """
   def call(conn, config) do
     conn
@@ -31,7 +31,10 @@ defmodule Plexy.RequestId do
     |> set_request_ids(Map.get(config, :res_header))
   end
 
-
+  @doc """
+  Reads the given headers for request ids, turns them into a list of binaries,
+  and prepends the new request id
+  """
   defp get_request_ids(conn, req_headers) do
     ids = Enum.reduce(req_headers, [], fn(header, acc) ->
       case get_request_id(conn, header) do
@@ -42,11 +45,17 @@ defmodule Plexy.RequestId do
     {conn, [Ecto.UUID.generate() | ids]}
   end
 
+  @doc """
+  Gets a list of request ids for a single header.
+  """
   defp get_request_id(conn, header) do
     Conn.get_req_header(conn, header)
     |> Enum.flat_map(&String.split(&1, ","))
   end
 
+  @doc """
+  Sets the request ids as the res_header, and adds it to conn.assigns
+  """
   defp set_request_ids({conn, request_ids}, header) do
     string = Enum.join(request_ids, ",")
     conn = Conn.put_resp_header(conn, header, string)

--- a/lib/request_id.ex
+++ b/lib/request_id.ex
@@ -1,24 +1,44 @@
 defmodule Plexy.RequestId do
+  @moduledoc """
+  Injects a request id into the specified header for each request. Leaves
+  existing request ids in tact.
+  """
   alias Plug.Conn
   @behaviour Plug
 
+  @doc """
+  Initializes the plug. Returns a map with req_headers and
+  res_headers for use by the other functions.
+  """
   def init(opts) do
-    %{req_headers:
-        Keyword.get(opts, :req_headers, ["request-id", "x-request-id"]),
-      res_header:
-        Keyword.get(opts, :res_header, "request-id")}
+    req_headers = case Keyword.get(opts, :req_headers, ["request-id", "x-request-id"]) do
+      v when is_list(v) -> v
+      v when is_binary(v) -> [v]
+    end
+
+    %{req_headers: req_headers,
+      res_header:  Keyword.get(opts, :res_header, "request-id")}
   end
 
+  @doc """
+  Takes the req_headers from the config and adds a UUID for our
+  request header and then shoves that all into the response header
+  also sets an assigns
+  """
   def call(conn, config) do
     conn
     |> get_request_ids(Map.get(config, :req_headers))
     |> set_request_ids(Map.get(config, :res_header))
   end
 
+
   defp get_request_ids(conn, req_headers) do
-    ids = Enum.map(req_headers, &get_request_id(conn, &1))
-          |> Enum.filter(&(&1))
-          |> Enum.flat_map(&(&1))
+    ids = Enum.reduce(req_headers, [], fn(header, acc) ->
+      case get_request_id(conn, header) do
+        []      -> acc
+        headers -> acc ++ headers
+      end
+    end)
     {conn, [Ecto.UUID.generate() | ids]}
   end
 

--- a/lib/request_id.ex
+++ b/lib/request_id.ex
@@ -44,7 +44,9 @@ defmodule Plexy.RequestId do
 
   defp get_request_id(conn, header) do
     Conn.get_req_header(conn, header)
-    |> Enum.flat_map(&String.split(&1, ","))
+    |> List.flatten()
+    |> Enum.map(&String.split(&1, ","))
+    |> List.flatten()
   end
 
   defp set_request_ids({conn, request_ids}, header) do

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Plexy.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:ecto, "~> 2.0"},
       {:plug, "~> 1.0"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,8 @@ defmodule Plexy.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [
+      {:plug, "~> 1.0"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,5 @@
-%{"mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
-  "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]}}
+%{"decimal": {:hex, :decimal, "1.2.0", "462960fd71af282e570f7b477f6be56bf8968e68277d4d0b641a635269bf4b0d", [:mix], []},
+  "ecto": {:hex, :ecto, "2.0.5", "7f4c79ac41ffba1a4c032b69d7045489f0069c256de606523c65d9f8188e502d", [:mix], [{:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/test/plexy/request_id_test.exs
+++ b/test/plexy/request_id_test.exs
@@ -1,0 +1,18 @@
+defmodule Plexy.RequestIdTest do
+  use ExUnit.Case
+
+  alias Plexy.RequestId
+
+  test "init has default config" do
+    config = RequestId.init([])
+
+    assert config.req_headers == ["request-id", "x-request-id"]
+    assert config.res_header == "request-id"
+  end
+
+  test "init allows config" do
+    config = RequestId.init(req_headers: ["my-foo-header"])
+
+    assert config.req_headers == ["my-foo-header"]
+  end
+end

--- a/test/plexy/request_id_test.exs
+++ b/test/plexy/request_id_test.exs
@@ -22,7 +22,6 @@ defmodule Plexy.RequestIdTest do
     conn = %Plug.Conn{}
     |> RequestId.call(RequestId.init([]))
 
-
     header = hd(Plug.Conn.get_resp_header(conn, "request-id"))
 
     assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, header)
@@ -36,7 +35,6 @@ defmodule Plexy.RequestIdTest do
     }
     |> RequestId.call(RequestId.init([]))
 
-
     header = hd(Plug.Conn.get_resp_header(conn, "request-id"))
 
     assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, header)
@@ -47,7 +45,6 @@ defmodule Plexy.RequestIdTest do
     conn = %Plug.Conn{}
     |> RequestId.call(RequestId.init([]))
 
-
     assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, 
                         conn.assigns.request_id)
   end
@@ -55,7 +52,6 @@ defmodule Plexy.RequestIdTest do
   test "adds request_ids to conn assigns" do
     conn = %Plug.Conn{}
     |> RequestId.call(RequestId.init([]))
-
 
     assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, 
                         hd(conn.assigns.request_ids))

--- a/test/plexy/request_id_test.exs
+++ b/test/plexy/request_id_test.exs
@@ -43,17 +43,18 @@ defmodule Plexy.RequestIdTest do
 
   test "keeps all existing request ids when mulitple exist" do
     conn = %Plug.Conn{
-      req_headers: %{
-        "request-id" => ["1234-abcd", "5678-defg"],
-        "x-request-id" => ["9876-zyxw,5432-vuts"],
-      }
+      req_headers: [
+        {"request-id", "1234-abcd"},
+        {"request-id", "5678-efgh"},
+        {"x-request-id", "9876-zyxw,5432-vuts"}
+      ]
     }
     |> RequestId.call(RequestId.init([]))
 
     request_id = hd(Plug.Conn.get_resp_header(conn, "request-id"))
 
     assert String.contains?(request_id, "1234-abcd")
-    assert String.contains?(request_id, "5678-defg")
+    assert String.contains?(request_id, "5678-efgh")
     assert String.contains?(request_id, "9876-zyxw")
     assert String.contains?(request_id, "5432-vuts")
 

--- a/test/plexy/request_id_test.exs
+++ b/test/plexy/request_id_test.exs
@@ -41,6 +41,25 @@ defmodule Plexy.RequestIdTest do
     assert String.ends_with?(header, ",1234-abc")
   end
 
+  test "keeps all existing request ids when mulitple exist" do
+    conn = %Plug.Conn{
+      req_headers: %{
+        "request-id" => ["1234-abcd", "5678-defg"],
+        "x-request-id" => ["9876-zyxw,5432-vuts"],
+      }
+    }
+    |> RequestId.call(RequestId.init([]))
+
+    request_id = hd(Plug.Conn.get_resp_header(conn, "request-id"))
+
+    assert String.contains?(request_id, "1234-abcd")
+    assert String.contains?(request_id, "5678-defg")
+    assert String.contains?(request_id, "9876-zyxw")
+    assert String.contains?(request_id, "5432-vuts")
+
+    assert length(String.split(request_id, ",")) == 5
+  end
+
   test "adds request_id to conn assigns" do
     conn = %Plug.Conn{}
     |> RequestId.call(RequestId.init([]))

--- a/test/plexy/request_id_test.exs
+++ b/test/plexy/request_id_test.exs
@@ -28,11 +28,7 @@ defmodule Plexy.RequestIdTest do
   end
 
   test "adds a request id header when one already exists" do
-    conn = %Plug.Conn{
-      req_headers: %{
-        "request-id" => "1234-abc"
-      }
-    }
+    conn = %Plug.Conn{req_headers: [{"request-id", "1234-abc"}]}
     |> RequestId.call(RequestId.init([]))
 
     header = hd(Plug.Conn.get_resp_header(conn, "request-id"))
@@ -53,10 +49,8 @@ defmodule Plexy.RequestIdTest do
 
     request_id = hd(Plug.Conn.get_resp_header(conn, "request-id"))
 
-    assert String.contains?(request_id, "1234-abcd")
-    assert String.contains?(request_id, "5678-efgh")
-    assert String.contains?(request_id, "9876-zyxw")
-    assert String.contains?(request_id, "5432-vuts")
+    assert String.contains?(request_id, "1234-abcd,5678-efgh")
+    assert String.contains?(request_id, "9876-zyxw,5432-vuts")
 
     assert length(String.split(request_id, ",")) == 5
   end
@@ -76,5 +70,4 @@ defmodule Plexy.RequestIdTest do
     assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, 
                         hd(conn.assigns.request_ids))
   end
-
 end

--- a/test/plexy/request_id_test.exs
+++ b/test/plexy/request_id_test.exs
@@ -11,8 +11,10 @@ defmodule Plexy.RequestIdTest do
   end
 
   test "init allows config" do
-    config = RequestId.init(req_headers: ["my-foo-header"])
+    config = RequestId.init(req_headers: ["my-foo-header"],
+                            res_header: "foobar-header")
 
     assert config.req_headers == ["my-foo-header"]
+    assert config.res_header == "foobar-header"
   end
 end

--- a/test/plexy/request_id_test.exs
+++ b/test/plexy/request_id_test.exs
@@ -17,4 +17,48 @@ defmodule Plexy.RequestIdTest do
     assert config.req_headers == ["my-foo-header"]
     assert config.res_header == "foobar-header"
   end
+
+  test "adds a request id header when none exists" do
+    conn = %Plug.Conn{}
+    |> RequestId.call(RequestId.init([]))
+
+
+    header = hd(Plug.Conn.get_resp_header(conn, "request-id"))
+
+    assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, header)
+  end
+
+  test "adds a request id header when one already exists" do
+    conn = %Plug.Conn{
+      req_headers: %{
+        "request-id" => "1234-abc"
+      }
+    }
+    |> RequestId.call(RequestId.init([]))
+
+
+    header = hd(Plug.Conn.get_resp_header(conn, "request-id"))
+
+    assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, header)
+    assert String.ends_with?(header, ",1234-abc")
+  end
+
+  test "adds request_id to conn assigns" do
+    conn = %Plug.Conn{}
+    |> RequestId.call(RequestId.init([]))
+
+
+    assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, 
+                        conn.assigns.request_id)
+  end
+
+  test "adds request_ids to conn assigns" do
+    conn = %Plug.Conn{}
+    |> RequestId.call(RequestId.init([]))
+
+
+    assert Regex.match?(~r/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/, 
+                        hd(conn.assigns.request_ids))
+  end
+
 end


### PR DESCRIPTION
Adds a plug that appends a new request id to every request. It also sets :request_id and :request_ids on the Conn's :assigns.

Implements #1.