### PR TITLE
Add a default value to the count function to assume 1

### DIFF
--- a/lib/plexy/logger.ex
+++ b/lib/plexy/logger.ex
@@ -38,8 +38,9 @@ defmodule Plexy.Logger do
 
       Plexy.Logger.count(:signup, 2)
       Plexy.Logger.count("registration", 1)
+      Plexy.Logger.count("registration") # same as above
   """
-  def count(metric, count) do
+  def count(metric, count \\ 1) do
     debug(%{metric_name(metric, :count) => count})
   end
 

--- a/test/plexy/logger_test.exs
+++ b/test/plexy/logger_test.exs
@@ -37,6 +37,14 @@ defmodule Plexy.LoggerTest do
     assert logged =~ "count#plexy.foo=1"
   end
 
+  test "logs counts for a given metric, assuming the count is one" do
+    logged = capture_log(fn ->
+      Logger.count(:foo)
+    end)
+
+    assert logged =~ "count#plexy.foo=1"
+  end
+
   test "logs time elapsed for given code block" do
     logged = capture_log(fn ->
       Logger.measure(:sleeping, fn ->


### PR DESCRIPTION
To me, it makes sense to default the vault of the count function to 1 as
that is the most often used count vault and makes the function a bit
more concise