### PR TITLE
Add measure logging in instrumentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Notably, Plexy is not a framework or a set of code generators. You can use Plexy
 
 ```elixir
 def deps do
-  [{:plexy, "~> 0.1.2"}]
+  [{:plexy, "~> 0.1.3"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ Plexy provides some helper functions for taking metric measurements and outputti
 
 #### Measures
 
-`Plexy.Logger.measure(metric_name, func)` will measure the amount of time in milliseconds required to run the given function and logs it as the given metric name.
+`Plexy.Logger.measure(metric_name, 123)` expects a time in milliseconds and logs it as the given metric name.
 
+`Plexy.Logger.measure(metric_name, func)` will measure the amount of time in milliseconds required to run the given function and logs it as the given metric name. This also returns the value of the given function.
 
 ### Configuring logging
 
@@ -114,6 +115,38 @@ config :logger, :console,
 ```
 
 Make sure that the `Plexy.RequestId` plug is included in your Elixir app per the Installation instructions, and you will have the `request_id` in the log metadata.
+
+By default Plexy looks for an ENV variable named `APP_NAME` and will then fall back to `plexy` if it is not provided. This value is used for metrics logging.
+
+```
+Plexy.Logger.measure(:fast, 123)
+# logs => measure#plexy.fast=123
+
+# APP_NAME env set to "my_app"
+Plexy.Logger.measure(:fast, 123)
+# logs => measure#my_app.fast=123
+```
+
+If you would like to use a different env var for the app name you can set it.
+
+```
+# config/config.exs
+config, :plexy,
+  app_name: {:system, "HEROKU_APP_NAME"}
+
+# HEROKU_APP_NAME env set to "much_amazing"
+Plexy.Logger.measure(:fast, 123)
+# logs => measure#much_amazing.fast=123
+
+# or with a default
+# config/config.exs
+config, :plexy,
+  app_name: {:system, "HEROKU_APP_NAME", "such_wow"}
+
+# HEROKU_APP_NAME env is not set
+Plexy.Logger.measure(:fast, 123)
+# logs => measure#such_wow.fast=123
+```
 
 ### Configuring exception reporting
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,15 @@ Plexy provides some helper functions for taking metric measurements and outputti
 
 `Plexy.Logger.measure(metric_name, 123)` expects a time in milliseconds and logs it as the given metric name.
 
-`Plexy.Logger.measure(metric_name, func)` will measure the amount of time in milliseconds required to run the given function and logs it as the given metric name. This also returns the value of the given function.
+`Plexy.Logger.measure(metric_name, func)` will measure the amount of time in milliseconds required to run the given function and logs it as the given metric name. This also returns the value of the given function. It also adds `.ms` to the metric in case you forget.
+
+```
+Plexy.Logger.measure(:fast, func)
+# logs => measure#plexy.fast.ms=123
+
+Plexy.Logger.measure("fast.ms", func)
+# logs => measure#my_app.fast.ms=123
+```
 
 ### Configuring logging
 

--- a/lib/plexy/instrumentor.ex
+++ b/lib/plexy/instrumentor.ex
@@ -34,7 +34,7 @@ defmodule Plexy.Instrumentor do
       stop = :erlang.monotonic_time()
       diff = :erlang.convert_time_unit(stop - start, :native, :milli_seconds)
 
-      Logger.measure("request.latency.milliseconds", diff)
+      Logger.measure("request.latency.ms", diff)
 
       Logger.log(
         level,

--- a/lib/plexy/instrumentor.ex
+++ b/lib/plexy/instrumentor.ex
@@ -34,6 +34,8 @@ defmodule Plexy.Instrumentor do
       stop = :erlang.monotonic_time()
       diff = :erlang.convert_time_unit(stop - start, :native, :milli_seconds)
 
+      Logger.measure("request.latency.milliseconds", diff)
+
       Logger.log(
         level,
         Keyword.merge(context,

--- a/lib/plexy/logger.ex
+++ b/lib/plexy/logger.ex
@@ -67,7 +67,7 @@ defmodule Plexy.Logger do
   """
   def measure(metric, fun) do
     {time, result} = :timer.tc(fun)
-    measure(metric, time / 1000.0)
+    measure(add_ms_to_metric_name(metric), time / 1000.0)
     result
   end
 
@@ -83,6 +83,14 @@ defmodule Plexy.Logger do
   end
 
   def log(level, chardata_or_fn, metadata), do: Logger.log(level, chardata_or_fn, metadata)
+
+  defp add_ms_to_metric_name(metric) do
+    if metric |> to_string() |> String.ends_with?(".ms") do
+      metric
+    else
+      "#{metric}.ms"
+    end
+  end
 
   defp metric_name(metric, name) when is_atom(metric) do
     metric |> to_string |> metric_name(name)

--- a/lib/plexy/logger.ex
+++ b/lib/plexy/logger.ex
@@ -46,6 +46,17 @@ defmodule Plexy.Logger do
   end
 
   @doc """
+  Logs a debug message and tags it as `metric`.
+
+  ## Examples
+
+      Plexy.Logger.measure(:request, 200)
+  """
+  def measure(metric, time) when is_number(time) do
+    debug(%{metric_name(metric, :measure) => time})
+  end
+
+  @doc """
   Logs a debug message the amount of time in milliseconds required to run
   the given function and tags it as `metric`.
 
@@ -56,7 +67,7 @@ defmodule Plexy.Logger do
   """
   def measure(metric, fun) do
     {time, result} = :timer.tc(fun)
-    debug(%{metric_name(metric, :measure) => time / 1000.0})
+    measure(metric, time / 1000.0)
     result
   end
 

--- a/lib/plexy/logger.ex
+++ b/lib/plexy/logger.ex
@@ -89,7 +89,7 @@ defmodule Plexy.Logger do
   end
 
   defp metric_name(metric, name) do
-    app = System.get_env("APP_NAME") || "plexy"
+    app = Plexy.Config.get(:plexy, :app_name, System.get_env("APP_NAME") || "plexy")
     name = to_string(name)
     "#{name}##{app}.#{metric}"
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plexy.Mixfile do
   def project do
     [
       app: :plexy,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.3",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/plexy/instrumentor_test.exs
+++ b/test/plexy/instrumentor_test.exs
@@ -25,19 +25,18 @@ defmodule Plexy.InstrumentorTest do
 
     [start_log_line, measure_log_line, finish_log_line | _empty_list] = String.split(logged, "\n")
 
-    assert start_log_line =~ "instrumentation"
-    assert start_log_line =~ "start"
-    assert start_log_line =~ "path"
-    assert start_log_line =~ "method"
+    assert start_log_line =~ "instrumentation=true"
+    assert start_log_line =~ "at=start"
+    assert start_log_line =~ "path=/foobar"
+    assert start_log_line =~ "method=GET"
 
-    assert measure_log_line =~ "measure"
-    assert measure_log_line =~ "request.latency.ms"
+    assert measure_log_line =~ "measure#plexy.request.latency.ms"
 
-    assert finish_log_line =~ "instrumentation"
-    assert finish_log_line =~ "finish"
+    assert finish_log_line =~ "instrumentation=true"
+    assert finish_log_line =~ "at=finish"
+    assert finish_log_line =~ "path=/foobar"
+    assert finish_log_line =~ "method=GET"
+    assert finish_log_line =~ "status=200"
     assert finish_log_line =~ "elapsed"
-    assert finish_log_line =~ "status"
-    assert finish_log_line =~ "path"
-    assert finish_log_line =~ "method"
   end
 end

--- a/test/plexy/instrumentor_test.exs
+++ b/test/plexy/instrumentor_test.exs
@@ -31,7 +31,7 @@ defmodule Plexy.InstrumentorTest do
     assert start_log_line =~ "method"
 
     assert measure_log_line =~ "measure"
-    assert measure_log_line =~ "request.latency.milliseconds"
+    assert measure_log_line =~ "request.latency.ms"
 
     assert finish_log_line =~ "instrumentation"
     assert finish_log_line =~ "finish"

--- a/test/plexy/instrumentor_test.exs
+++ b/test/plexy/instrumentor_test.exs
@@ -15,21 +15,7 @@ defmodule Plexy.InstrumentorTest do
   end
 
   @opts Instrumentor.init([])
-  test "Instrumentor.call/2 logs the start" do
-    logged =
-      capture_log(fn ->
-        conn(:get, "/foobar") |> Instrumentor.call(@opts)
-      end)
-
-    [start_log_line | _finish_log_line] = String.split(logged, "\n")
-
-    assert start_log_line =~ "instrumentation"
-    assert start_log_line =~ "start"
-    assert start_log_line =~ "path"
-    assert start_log_line =~ "method"
-  end
-
-  test "Instrumentor.call/2 logs the finish" do
+  test "Instrumentor.call/2 logging" do
     logged =
       capture_log(fn ->
         conn(:get, "/foobar")
@@ -37,7 +23,15 @@ defmodule Plexy.InstrumentorTest do
         |> Plug.Conn.send_resp(200, "wow")
       end)
 
-    [_start_log_line, finish_log_line | _empty_list] = String.split(logged, "\n")
+    [start_log_line, measure_log_line, finish_log_line | _empty_list] = String.split(logged, "\n")
+
+    assert start_log_line =~ "instrumentation"
+    assert start_log_line =~ "start"
+    assert start_log_line =~ "path"
+    assert start_log_line =~ "method"
+
+    assert measure_log_line =~ "measure"
+    assert measure_log_line =~ "request.latency.milliseconds"
 
     assert finish_log_line =~ "instrumentation"
     assert finish_log_line =~ "finish"

--- a/test/plexy/logger_test.exs
+++ b/test/plexy/logger_test.exs
@@ -58,7 +58,7 @@ defmodule Plexy.LoggerTest do
         end)
       end)
 
-    assert logged =~ "measure#plexy.sleeping=1"
+    assert logged =~ "measure#plexy.sleeping.ms=1"
   end
 
   test "redacts configured keys" do


### PR DESCRIPTION
This logging adds a measure that can show up in librato logs, this is needed for SLI

### Prerequisite to merging
- [x] merge https://github.com/heroku/plexy/pull/25
- [x] merge https://github.com/heroku/plexy/pull/27
- [x] rebase master after formatter pr is merged