### PR TITLE
Add Config module to Plexy

### DIFF
--- a/lib/plexy/config.ex
+++ b/lib/plexy/config.ex
@@ -1,0 +1,114 @@
+defmodule Plexy.Config do
+  @moduledoc """
+  Provides access to a hard coded config value, a value stored as a environment
+  variable on the current system at runtime or a default provided value.
+
+  The config.exs can look like this
+  ```
+  config :plexy,
+    redis_url: {:system, "REDIS_URL"},
+    port: {:system, "PORT", 5000},
+    normal: "normal"
+  ```
+
+  When using this modules `get/3` function, System.get_env("REDIS_URL") will be
+  ran at runtime.
+  """
+
+  defmacro __using__(opts \\ [name: :plexy]) do
+    unless opts[:name] do
+      raise "Option `:name` missing from configuration"
+    end
+
+    quote do
+      def get(key, default \\ nil) do
+        Plexy.Config.get(unquote(opts[:name]), key, default)
+      end
+
+      def get_int(key, default \\ nil) do
+        Plexy.Config.get_int(unquote(opts[:name]), key, default)
+      end
+
+      def get_bool(key, default \\ nil) do
+        Plexy.Config.get_bool(unquote(opts[:name]), key, default)
+      end
+    end
+  end
+
+  @doc """
+  Used to gain access to the application env.
+    ## Examples
+
+       iex> Application.put_env(:my_config, :redis_url, "redis://localhost:6379")
+       iex> Plexy.Config.get(:my_config, :redis_url)
+       "redis://localhost:6379"
+       iex> Plexy.Config.get(:my_config, :foo, "and a default")
+       "and a default"
+  """
+  def get(config_name, key, default \\ nil) do
+    config_name
+    |> Application.get_env(key, default)
+    |> resolve(default)
+  end
+
+  @doc """
+  Like `get/3` except it attempts to convert the value to an integer.
+    ## Examples
+       iex> Application.put_env(:my_config, :port, "5000")
+       iex> Plexy.Config.get_int(:my_config, :port, 9999)
+       5000
+       iex> Plexy.Config.get_int(:my_config, :foo, "123")
+       123
+  """
+  def get_int(config_name, key, default \\ nil) do
+    case get(config_name, key, default) do
+      value when is_integer(value) ->
+        value
+
+      value when is_binary(value) ->
+        String.to_integer(value)
+
+      _error ->
+        raise "Attempted to parse a value #{key} that could not be converted to an integer"
+    end
+  end
+
+  @doc """
+  Like `get/3` except it attempts to convert the value to an bool.
+    ## Examples
+       iex> Plexy.Config.get_bool(:my_config, :bar, "true")
+       true
+       iex> Plexy.Config.get_bool(:my_config, :bar, "yes")
+       true
+       iex> Plexy.Config.get_bool(:my_config, :foo, "0")
+       false
+       iex> Plexy.Config.get_bool(:my_config, :baz, "no")
+       false
+       iex> Plexy.Config.get_bool(:my_config, :baz, "false")
+       false
+       iex> Plexy.Config.get_bool(:my_config, :baz, nil)
+       false
+  """
+  def get_bool(config_name, key, default \\ nil) do
+    case get(config_name, key, default) do
+      value when value in [false, "false", "f", 0, "0", "no", "n", nil] ->
+        false
+
+      _value ->
+        true
+    end
+  end
+
+  @doc false
+  defp resolve({:system, var_name, config_default}, _default) do
+    System.get_env(var_name) || config_default
+  end
+
+  defp resolve({:system, var_name}, default) do
+    System.get_env(var_name) || default
+  end
+
+  defp resolve(value, _default) do
+    value
+  end
+end

--- a/test/plexy/config_test.exs
+++ b/test/plexy/config_test.exs
@@ -1,0 +1,4 @@
+defmodule Plexy.ConfigTest do
+  use ExUnit.Case
+  doctest Plexy.Config
+end

--- a/test/plexy/instrumentor_test.exs
+++ b/test/plexy/instrumentor_test.exs
@@ -1,7 +1,7 @@
 defmodule Plexy.InstrumentorTest do
   alias Plexy.Instrumentor
   import ExUnit.CaptureLog
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   use Plug.Test
 
   test "Instrumentor.init/1 defaults level to :info" do


### PR DESCRIPTION
Several projects have created or used logic similar to this. It would be nice to converge on a solution and have it out of the box.

Example of how to use this code:
```
# config/config.exs
config :my_app,
  some_var_that_exists: {:system, "SOME_VAR"},
  some_var_that_might_not_exist_with_default: {:system, "OTHER_VAR", "123"}

# lib/my_app/config.ex
defmodule MyApp.Config do
  use Plexy.Config, name: :my_app
end

# somewhere in code
MyApp.Config.get_int(:some_var_that_might_not_exist_with_default)
# => 123
MyApp.Config.get_bool(:some_var_that_exists)
# => false

# or use Plexy.Config directly
Plexy.Config.get(:my_app, :foo, :my_default)
# => :my_default
```

The great thing about this solution is that it's completely optional, which follows the "opt-in", "not a framework" philosophy of Plexy.