### PR TITLE
Set info to default measure log

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Notably, Plexy is not a framework or a set of code generators. You can use Plexy
 
 ```elixir
 def deps do
-  [{:plexy, "~> 0.1.4"}]
+  [{:plexy, "~> 0.1.5"}]
 end
 ```
 

--- a/lib/plexy/logger.ex
+++ b/lib/plexy/logger.ex
@@ -33,7 +33,7 @@ defmodule Plexy.Logger do
   end
 
   @doc """
-  Logs a debug message with the given metric as a count
+  Logs a info message with the given metric as a count
 
   ## Examples
 
@@ -42,22 +42,22 @@ defmodule Plexy.Logger do
       Plexy.Logger.count("registration") # same as above
   """
   def count(metric, count \\ 1) do
-    debug(%{metric_name(metric, :count) => count})
+    info(%{metric_name(metric, :count) => count})
   end
 
   @doc """
-  Logs a debug message and tags it as `metric`.
+  Logs a info message and tags it as `metric`.
 
   ## Examples
 
       Plexy.Logger.measure(:request, 200)
   """
   def measure(metric, time) when is_number(time) do
-    debug(%{metric_name(metric, :measure) => time})
+    info(%{metric_name(metric, :measure) => time})
   end
 
   @doc """
-  Logs a debug message the amount of time in milliseconds required to run
+  Logs a info message the amount of time in milliseconds required to run
   the given function and tags it as `metric`.
 
   ## Examples

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plexy.Mixfile do
   def project do
     [
       app: :plexy,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.3",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Phoenix by default logs only info level and above (not debug). We should make this work out of the box.