### PR TITLE
Get nested configs

### DIFF
--- a/lib/plexy/config.ex
+++ b/lib/plexy/config.ex
@@ -42,9 +42,9 @@ defmodule Plexy.Config do
     ## Examples
 
        iex> Application.put_env(:my_config, HerokuApi, heroku_api_url: "https://api.heroku.com")
-       iex> Plexy.Config.get(:my_config, [HerokuApi, :heroku_api_url])
+       iex> Plexy.Config.get(:my_config, {HerokuApi, :heroku_api_url})
        "https://api.heroku.com"
-       iex> Plexy.Config.get(:my_config, [HerokuApi, :not_set], "and a default")
+       iex> Plexy.Config.get(:my_config, {HerokuApi, :not_set}, "and a default")
        "and a default"
 
        iex> Application.put_env(:my_config, :redis_url, "redis://localhost:6379")
@@ -53,10 +53,10 @@ defmodule Plexy.Config do
        iex> Plexy.Config.get(:my_config, :foo, "and a default")
        "and a default"
   """
-  @spec get(atom(), atom() | [atom(), ...], any()) :: any()
+  @spec get(atom(), atom() | {atom(), atom()}, any()) :: any()
   def get(config_name, key, default \\ nil)
 
-  def get(config_name, [key | keys], default) do
+  def get(config_name, {module_name, key}, default) when is_atom(module_name) and is_atom(key) do
     default_resolver = fn
       nil ->
         default
@@ -66,8 +66,8 @@ defmodule Plexy.Config do
     end
 
     config_name
-    |> Application.get_env(key)
-    |> get_in(keys)
+    |> Application.get_env(module_name)
+    |> get_in([key])
     |> default_resolver.()
     |> resolve(default)
   end

--- a/lib/plexy/config.ex
+++ b/lib/plexy/config.ex
@@ -15,6 +15,8 @@ defmodule Plexy.Config do
   ran at runtime.
   """
 
+  alias __MODULE__
+
   defmacro __using__(opts \\ [name: :plexy]) do
     unless opts[:name] do
       raise "Option `:name` missing from configuration"
@@ -22,15 +24,15 @@ defmodule Plexy.Config do
 
     quote do
       def get(key, default \\ nil) do
-        Plexy.Config.get(unquote(opts[:name]), key, default)
+        Config.get(unquote(opts[:name]), key, default)
       end
 
       def get_int(key, default \\ nil) do
-        Plexy.Config.get_int(unquote(opts[:name]), key, default)
+        Config.get_int(unquote(opts[:name]), key, default)
       end
 
       def get_bool(key, default \\ nil) do
-        Plexy.Config.get_bool(unquote(opts[:name]), key, default)
+        Config.get_bool(unquote(opts[:name]), key, default)
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plexy.Mixfile do
   def project do
     [
       app: :plexy,
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
[W-6818927](https://gus.lightning.force.com/a07B0000007bPs6IAE)

This allows for nested to configs to be used by plexy

Example:
```elixir
# config/config.exs
config :my_otp_app, HerokuApi,
  heroku_api_url: {:system, "HEROKU_API_URL", "https://api.heroku.com"}

# MyOtpApp.Config.ex
defmodule MyOtpApp.Config do
  use Plexy.Config, name: :my_otp_app
end

# somwhere in code
MyOtpApp.Config.get([HerokuApi, :heroku_api_url])
# => "https://api.heroku.com" (unless the environment var HEROKU_API_URL is set)
```
