### PR TITLE
Add app name to `Plexy.Logger.log\2`

### DIFF
--- a/lib/plexy/instrumentor.ex
+++ b/lib/plexy/instrumentor.ex
@@ -4,8 +4,8 @@ defmodule Plexy.Instrumentor do
   instrumentation at=start method=get path=/apps
   instrumentation at=finish method=get path=/apps elapsed=100 status=200
   """
-  alias Plug.Conn
   alias Plexy.Logger
+  alias Plug.Conn
   @behaviour Plug
 
   @doc """

--- a/lib/plexy/logger.ex
+++ b/lib/plexy/logger.ex
@@ -107,6 +107,7 @@ defmodule Plexy.Logger do
 
   defp list_to_line(datum) when is_list(datum) or is_map(datum) do
     datum
+    |> decorate_with_app_name()
     |> Enum.reduce("", &pair_to_segment/2)
     |> String.trim_trailing(" ")
     |> redact()

--- a/lib/plexy/logger.ex
+++ b/lib/plexy/logger.ex
@@ -4,6 +4,7 @@ defmodule Plexy.Logger do
   handle non char-data and has a few other helpful logging functions.
   """
 
+  alias Plexy.Config
   require Logger
 
   @overrides [:info, :warn, :debug, :error]
@@ -102,7 +103,7 @@ defmodule Plexy.Logger do
   end
 
   defp app_name do
-    Plexy.Config.get(:plexy, :app_name) || raise "You must set app_name for Plexy config"
+    Config.get(:plexy, :app_name) || raise "You must set app_name for Plexy config"
   end
 
   defp list_to_line(datum) when is_list(datum) or is_map(datum) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Plexy.Mixfile do
   def project do
     [
       app: :plexy,
-      version: "0.3.2",
+      version: "0.3.3",
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/plexy/instrumentor_test.exs
+++ b/test/plexy/instrumentor_test.exs
@@ -38,6 +38,7 @@ defmodule Plexy.InstrumentorTest do
       | _anything_else
     ] = String.split(logged, "\n")
 
+    assert start_log_line =~ "app=#{@test_app_name}"
     assert start_log_line =~ "instrumentation=true"
     assert start_log_line =~ "at=start"
     assert start_log_line =~ "path=/foobar"
@@ -48,6 +49,7 @@ defmodule Plexy.InstrumentorTest do
     assert status_log_line =~ "count##{@test_app_name}.requests.203"
     assert status_class_log_line =~ "count##{@test_app_name}.requests.2xx"
 
+    assert finish_log_line =~ "app=#{@test_app_name}"
     assert finish_log_line =~ "instrumentation=true"
     assert finish_log_line =~ "at=finish"
     assert finish_log_line =~ "path=/foobar"

--- a/test/plexy/instrumentor_test.exs
+++ b/test/plexy/instrumentor_test.exs
@@ -1,5 +1,6 @@
 defmodule Plexy.InstrumentorTest do
   alias Plexy.Instrumentor
+  alias Plug.Conn
   import ExUnit.CaptureLog
   use ExUnit.Case
   use Plug.Test
@@ -26,7 +27,7 @@ defmodule Plexy.InstrumentorTest do
       capture_log(fn ->
         conn(:get, "/foobar")
         |> Instrumentor.call(@opts)
-        |> Plug.Conn.send_resp(203, "wow")
+        |> Conn.send_resp(203, "wow")
       end)
 
     [

--- a/test/plexy/logger_test.exs
+++ b/test/plexy/logger_test.exs
@@ -40,6 +40,7 @@ defmodule Plexy.LoggerTest do
 
   test "logs functions with interpolated strings" do
     inside = "inside"
+
     logged =
       capture_log(fn ->
         Logger.debug(fn -> "interpolated string #{inside} fn" end)
@@ -120,6 +121,24 @@ defmodule Plexy.LoggerTest do
       end)
 
     assert logged =~ "app=passed-test-app-name"
+  end
+
+  test "includes app name from config" do
+    logged =
+      capture_log(fn ->
+        Logger.debug(my_message: "mystuff")
+      end)
+
+    assert logged =~ "app=#{@test_app_name}"
+  end
+
+  test "includes app name from config, when using `log`" do
+    logged =
+      capture_log(fn ->
+        Logger.log(:debug, my_message: "mystuff")
+      end)
+
+    assert logged =~ "app=#{@test_app_name}"
   end
 
   describe "when app name is not set in the config" do


### PR DESCRIPTION
[W-6851525](https://gus.lightning.force.com/a07B00000077ZDrIAM)

Discovered because the Instrumentor was not logging the app_name.
This will also fix any app using the Plexy.Logger.log\2 function.