### PR TITLE
Fix the Rollbax URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Plexy.Logger.measure(:fast, 123)
 
 ### Configuring exception reporting
 
-We recommend [Rollbax](https://github.com/elixir-addicts/rollbax) as it lives in your logging backends pipeline. This means that the params retracted by the Plexy Redactor won't ever show up in Rollbar. To hide certain keys from your Rollbar reporting, see the next section.
+We recommend [Rollbax](https://github.com/ForzaElixir/rollbax) as it lives in your logging backends pipeline. This means that the params retracted by the Plexy Redactor won't ever show up in Rollbar. To hide certain keys from your Rollbar reporting, see the next section.
 
 ### Protecting secrets from appearing in logs or Rollbar
 


### PR DESCRIPTION
Rollbax package has moved to a new GitHub account. 

This PR updates the new Rollbax package link